### PR TITLE
chore: import repository https://github.com/executeinc/node-http-jx-quickstart.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -10,6 +10,12 @@ spec:
     repositories:
     - name: node-http-jx-quickstart
     scheduler: in-repo
+  - owner: executeinc
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: node-http-jx-quickstart
+    scheduler: in-repo
   slack:
     channel: '#jenkins-x-pipelines'
     kind: failureOrNextSuccess


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
